### PR TITLE
Update libraries to fix crash when skipping back in the audiobook player

### DIFF
--- a/build_libraries.toml
+++ b/build_libraries.toml
@@ -22,8 +22,7 @@ irradia_mime = "1.1.1"
 irradia_opds2 = "0.0.7"
 jackson = "2.10.2"
 jackson_kotlin = "2.9.9"
-javax_annotation_api = "1.2-b01"
-javax_annotations = "1.2-b01"
+javax_annotation_api = "1.3.2"
 jcip = "1.0.2"
 jcip_annotations = "1.0-1"
 joda_time = "2.10.10"
@@ -50,7 +49,7 @@ okio = "3.5.0"
 orgjson = "20200518"
 osgi_bundle_annotation = "1.0.0"
 osgi_bundle_version_annotation = "1.0.0"
-palace_audiobook = "11.5.0"
+palace_audiobook = "11.6.0"
 palace_drm_adobe = "1.2.7"
 palace_drm_core = "1.2.7"
 palace_findaway = "6.0.8"
@@ -362,10 +361,10 @@ palace_readium2_vanilla = { module = "org.thepalaceproject.r2:org.librarysimplif
 palace_readium2_views = { module = "org.thepalaceproject.r2:org.librarysimplified.r2.views", version.ref = "palace_readium2" }
 palace_readium2_ui_thread = { module = "org.thepalaceproject.r2:org.librarysimplified.r2.ui_thread", version.ref = "palace_readium2" }
 
-r2_lcp = { module = "com.github.readium.kotlin-toolkit:readium-lcp", version = "2.2.1" }
-r2_opds = { module = "com.github.readium.kotlin-toolkit:readium-opds", version = "2.2.1" }
-r2_shared = { module = "com.github.readium.kotlin-toolkit:readium-shared", version = "2.2.1" }
-r2_streamer = { module = "com.github.readium.kotlin-toolkit:readium-streamer", version = "2.2.1" }
+r2_lcp = { module = "org.readium.kotlin-toolkit:readium-lcp", version = "2.4.0" }
+r2_opds = { module = "org.readium.kotlin-toolkit:readium-opds", version = "2.4.0" }
+r2_shared = { module = "org.readium.kotlin-toolkit:readium-shared", version = "2.4.0" }
+r2_streamer = { module = "org.readium.kotlin-toolkit:readium-streamer", version = "2.4.0" }
 readium_lcp = { module = "readium:liblcp", version = "2.0.0" }
 
 jsoup = { module = "org.jsoup:jsoup", version = "1.7.2" }
@@ -478,12 +477,19 @@ hamcrest = { module = "org.hamcrest:hamcrest", version = "2.2" }
 io7m_jfunctional = { module = "com.io7m.jfunctional:io7m-jfunctional-core", version.ref = "io7m_jfunctional" }
 io7m_jnull = { module = "com.io7m.jnull:io7m-jnull-core", version.ref = "io7m_jnull" }
 io7m_junreachable = { module = "com.io7m.junreachable:io7m-junreachable-core", version.ref = "io7m_junreachable" }
-javax_annotation_api = { module = "javax.annotation:javax.annotation-api", version.ref = "javax_annotations" }
+javax_annotation_api = { module = "javax.annotation:javax.annotation-api", version.ref = "javax_annotation_api" }
 jcip = { module = "com.io7m.jcip:jcip-annotations", version.ref = "jcip" }
 jcip_annotations = { module = "com.github.stephenc.jcip:jcip-annotations", version.ref = "jcip_annotations" }
 joda_time = { module = "joda-time:joda-time", version.ref = "joda_time" }
 kxml = { module = "net.sf.kxml:kxml2", version.ref = "kxml" }
 leak_canary = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "leak_canary" }
+media3_common = { module = "androidx.media3:media3-common", version = "1.2.0" }
+media3_container = { module = "androidx.media3:media3-container", version = "1.2.0" }
+media3_datasource = { module = "androidx.media3:media3-datasource", version = "1.2.0" }
+media3_decoder = { module = "androidx.media3:media3-decoder", version = "1.2.0" }
+media3_exoplayer = { module = "androidx.media3:media3-exoplayer", version = "1.2.0" }
+media3_extractor = { module = "androidx.media3:media3-extractor", version = "1.2.0" }
+media3_session = { module = "androidx.media3:media3-session", version = "1.2.0" }
 nano_httpd = { module = "com.github.readium.nanohttpd:nanohttpd", version.ref = "nano_httpd" }
 nano_httpd_nanolets = { module = "com.github.readium.nanohttpd:nanohttpd-nanolets", version.ref = "nano_httpd_nanolets" }
 nypl_drm_adobe = { module = "org.librarysimplified.drm.adobe:org.librarysimplified.drm.adobe.provider", version.ref = "nypl_drm_adobe" }


### PR DESCRIPTION
Updating libraries to fix crash when skipping back in the audiobook player

Issue: [SIMPLYE-333](https://jira.lingsoft.fi/browse/SIMPLYE-333)
