### PR TITLE
EKIR-269 Update kotlin toolkit to 2.4.1

### DIFF
--- a/build_libraries.toml
+++ b/build_libraries.toml
@@ -361,10 +361,10 @@ palace_readium2_vanilla = { module = "org.thepalaceproject.r2:org.librarysimplif
 palace_readium2_views = { module = "org.thepalaceproject.r2:org.librarysimplified.r2.views", version.ref = "palace_readium2" }
 palace_readium2_ui_thread = { module = "org.thepalaceproject.r2:org.librarysimplified.r2.ui_thread", version.ref = "palace_readium2" }
 
-r2_lcp = { module = "org.readium.kotlin-toolkit:readium-lcp", version = "2.4.0" }
-r2_opds = { module = "org.readium.kotlin-toolkit:readium-opds", version = "2.4.0" }
-r2_shared = { module = "org.readium.kotlin-toolkit:readium-shared", version = "2.4.0" }
-r2_streamer = { module = "org.readium.kotlin-toolkit:readium-streamer", version = "2.4.0" }
+r2_lcp = { module = "org.readium.kotlin-toolkit:readium-lcp", version = "2.4.1" }
+r2_opds = { module = "org.readium.kotlin-toolkit:readium-opds", version = "2.4.1" }
+r2_shared = { module = "org.readium.kotlin-toolkit:readium-shared", version = "2.4.1" }
+r2_streamer = { module = "org.readium.kotlin-toolkit:readium-streamer", version = "2.4.1" }
 readium_lcp = { module = "readium:liblcp", version = "2.0.0" }
 
 jsoup = { module = "org.jsoup:jsoup", version = "1.7.2" }


### PR DESCRIPTION
Update the kotlin-toolkit files to enable support for the new 2.x LCP Profiles.

Ref: https://jira.it.helsinki.fi/browse/EKIRJASTO-269